### PR TITLE
.github: fix job name

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -43,7 +43,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-
 
-    - name: Uint Test
+    - name: Unit Test
       env:
         ANDROID_HOME: "" # Skip android test
       run: |


### PR DESCRIPTION
### Description

Fixes the github action job name.

### Rationale

Currently shows as this:
![image](https://user-images.githubusercontent.com/677006/194493104-8d1d9543-295d-48b2-bcca-ebc84b499b30.png)

### Changes

Notable changes: 
* Only changes the github action job name.
